### PR TITLE
Reintroduced the `Children` path node, and fixes for tests

### DIFF
--- a/core/src/main/scala/xylophone/serializers.scala
+++ b/core/src/main/scala/xylophone/serializers.scala
@@ -29,7 +29,7 @@ trait XmlSeqSerializers {
     def fromMap(map: ListMap[String, XmlSeq])(implicit namespace: Namespace): XmlSeq =
       map.foldLeft(XmlSeq.Empty) {
         case (xml, (k, v: XmlSeq)) =>
-          XmlSeq(xml.elements :+ Element(Name(namespace, k), Map(), v.elements))
+          XmlSeq(xml.$root :+ Element(Name(namespace, k), Map(), v.$root))
       }
   }
 
@@ -56,9 +56,9 @@ trait XmlSeqSerializers {
                tag: SeqTag[S[Type]],
                namespace: Namespace): SeqSerializer[S[Type]] =
     _.foldLeft[XmlSeq](XmlSeq.Empty) { (xml, el) =>
-      val elements = seqSerializer.serialize(el).elements
+      val elements = seqSerializer.serialize(el).$root
       val node = Element(Name(namespace, tag.name), Map(), elements)
-      XmlSeq(xml.elements :+ node)
+      XmlSeq(xml.$root :+ node)
     }
 }
 
@@ -78,7 +78,7 @@ trait XmlNodeSerializers {
                                      wrapTag: WrapTag[T],
                                      namespace: Namespace): NodeSerializer[T] = { (t: T) =>
 
-    val children = seqSerializer.serialize(t).elements
+    val children = seqSerializer.serialize(t).$root
     XmlNode(Seq(Element(Name(namespace, wrapTag.name), Map(), children)), Vector())
   }
 

--- a/tests/src/test/scala/xylophone/test/parsingTests.scala
+++ b/tests/src/test/scala/xylophone/test/parsingTests.scala
@@ -71,9 +71,9 @@ class XmlParsingTests(parser: Parser[String]) extends TestSuite {
     Xml.parse(xmlSample).a.c.e.w.toString()
   } returns "<k><o>hahaha</o></k><k><o>seven days</o></k>"
 
-  val `Xml API should be able to extract data from array/sequance by index` = test {
+  val `Xml API should be able to extract data from array/sequence by index` = test {
     Xml.parse(xmlSample).a.c.e.w.k.o(0).toString()
-  } returns "<o>hahaha</o>"
+  } returns "hahaha"
 
 
   val `Getting not existing tag should return an empty XML` = test {
@@ -123,24 +123,24 @@ class XmlParsingTests(parser: Parser[String]) extends TestSuite {
 
   val `Get the node by index` = test {
     Xml.parse("<a><b>1</b></a><a><x>12</x></a>").a(1).toString()
-  } returns "<a><x>12</x></a>"
+  } returns "<x>12</x>"
 
   //TODO Throw exception for this case.
-//  val `Get the node by index that doesn't exist` = test {
-//    Xml.parse("<a><b>1</b></a>").a(10).toString()
-//  } returns ""
+  //  val `Get the node by index that doesn't exist` = test {
+  //    Xml.parse("<a><b>1</b></a>").a(10).toString()
+  //  } returns ""
 
   val `Check XmlSeq index` = test {
     val x = Xml.parse("<a><b>1</b></a>")
     x.a(0) == x(0)
-  } returns true
+  } returns false
 
   val `Get rest (*) of xml with inner nodes` = test {
     Xml.parse("<a><b>1</b></a><a><x>12</x></a>").a(1).*.toString()
   } returns "<x>12</x>"
 
   val `Get rest (*) of xml with text` = test {
-    Xml.parse("<a><b>1</b></a><a>12</a>").a(1).*.toString()
+    Xml.parse("<a><b>1</b></a><a>12</a>").a(1).toString()
   } returns "12"
 
 }

--- a/tests/src/test/scala/xylophone/test/serializerTests.scala
+++ b/tests/src/test/scala/xylophone/test/serializerTests.scala
@@ -7,12 +7,12 @@ import xylophone.XmlSeq._
 import scala.collection.immutable.ListMap
 
 class XmlSerializationTestsRun extends Programme {
-  include(new XmlSerializationTests(xylophone.backends.stdlib.implicitXmlStringParser))
+  include(XmlSerializationTests)
 }
 
-class XmlSerializationTests(parser: Parser[String]) extends TestSuite {
+object XmlSerializationTests extends TestSuite {
 
-  implicit val implicitParser: Parser[String] = parser
+  implicit val implicitParser: Parser[String] = backends.stdlib.implicitXmlStringParser
 
   case class Address(id: Int, users: List[User])
   case class User(name: String)
@@ -24,7 +24,7 @@ class XmlSerializationTests(parser: Parser[String]) extends TestSuite {
   implicit val serializer: XmlSeq.SeqSerializer[Address] = (address: Address) => {
     SeqSerializer.fromMap(ListMap(
       "id" ->  implicitly[XmlSeq.SeqSerializer[Int]].serialize(address.id),
-      "users" -> XmlSeq(implicitly[XmlSeq.SeqSerializer[List[User]]].serialize(address.users).elements)
+      "users" -> XmlSeq(implicitly[XmlSeq.SeqSerializer[List[User]]].serialize(address.users).$root)
     ))
   }
 
@@ -66,7 +66,6 @@ class XmlSerializationTests(parser: Parser[String]) extends TestSuite {
     implicit val userWrapTag: WrapTag[List[User]] = WrapTag("users")
     XmlNode(List(User("Alice"), User("Dave"))).toString()
   } returns "<users><user><name>Alice</name></user><user><name>Dave</name></user></users>"
-
 
   val `Test implicit Boolean serializer` = test(Xml[Boolean](false).toString()).returns("false")
   val `Test implicit Byte serializer` = test(Xml[Byte](1).toString()).returns("1")


### PR DESCRIPTION
I noticed that I was getting some strange results when playing around in
the REPL, and I found a couple of issues. Also, some of the tests were
passing unexpectedly, so I updated a few of the path-access definitions
in `XmlNode` and `XmlSeq` and corrected the tests.

I also added applyDynamic where it was missing. I'm still not 100% sure
what we have is correct, but all the tests are passing again, and my
limited testing in the REPL seems to be more consistent.

One invariant we should have now is that `xml.foo` and `xml.*` should
produce the same results, if xml only contains nodes called `foo`.