### PR TITLE
Xml interpolator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+Version 1.0.1
+
+- Prevent inference of a too-narrow return type from type embeddings, causing
+  implicit embeddings not to be found.
+

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 
 val versions = new {
   val rapture = "2.0.0-M8"
-  val contextual = "1.0.0"
+  val contextual = "1.0.1"
   val scalaMacros = "2.1.0"
   val macroCompat = "1.1.1"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import ReleaseTransformations._
 
 val versions = new {
   val rapture = "2.0.0-M8"
+  val contextual = "1.0.0"
   val scalaMacros = "2.1.0"
   val macroCompat = "1.1.1"
 }
@@ -23,7 +24,8 @@ lazy val stdlib = project
   .settings(publishSettings: _*)
   .settings(moduleName := "xylophone-stdlib")
   .settings(libraryDependencies ++= Seq(
-    "com.propensive" %% "rapture-core" % versions.rapture
+    "com.propensive" %% "rapture-core" % versions.rapture,
+    "com.propensive" %% "contextual" % versions.contextual
   ))
   .dependsOn(core)
 

--- a/stdlib/src/main/scala/xylophone/backends/interpolator.scala
+++ b/stdlib/src/main/scala/xylophone/backends/interpolator.scala
@@ -1,0 +1,7 @@
+package xylophone.backends
+
+import contextual._
+
+object XmlInterpolator extends Interpolator {
+
+}

--- a/stdlib/src/main/scala/xylophone/backends/interpolator.scala
+++ b/stdlib/src/main/scala/xylophone/backends/interpolator.scala
@@ -6,26 +6,26 @@ import contextual._
 object XmlInterpolator extends Interpolator {
 
   implicit val embedStrings = XmlInterpolator.embed[String](
-    Case(AttributeEquals, InTagBody) { s => StringLike('"'+s+'"'): Input },
-    Case(AttributeValue, AttributeValue) { s => StringLike(s): Input },
+    Case(AttributeEquals, InTagBody) { s => StringLike('"'+s+'"') },
+    Case(AttributeValue, AttributeValue) { s => StringLike(s) },
     Case(Body, Body) { s => StringLike(s) }
   )
 
   implicit val embedXmlSeqs = XmlInterpolator.embed[XmlSeq](
-    Case(Body, Body) { x => XmlLike(x): Input }
+    Case(Body, Body) { x => XmlLike(x) }
   )
 
   implicit val embedXmlNodes = XmlInterpolator.embed[XmlNode](
-    Case(Body, Body) { x => XmlLike(XmlSeq(x.$root, x.$path)): Input }
+    Case(Body, Body) { x => XmlLike(XmlSeq(x.$root, x.$path)) }
   )
 
   implicit val embedPairs = XmlInterpolator.embed[(String, String)](
-    Case(InTagBody, InTagBody) { p => StringLike(s""" ${p._1}="${p._2}" """): Input }
+    Case(InTagBody, InTagBody) { p => StringLike(s""" ${p._1}="${p._2}" """) }
   )
   
   implicit val embedStringMap = XmlInterpolator.embed[Map[String, String]](
     Case(InTagBody, InTagBody) { m =>
-      StringLike(m.map { case (k, v) => k+"="+'"'+v+'"' }.mkString(" ", " ", " ")): Input }
+      StringLike(m.map { case (k, v) => k+"="+'"'+v+'"' }.mkString(" ", " ", " ")) }
   )
 
   sealed trait Input

--- a/stdlib/src/main/scala/xylophone/backends/interpolator.scala
+++ b/stdlib/src/main/scala/xylophone/backends/interpolator.scala
@@ -1,7 +1,18 @@
-package xylophone.backends
+package xylophone.backends.stdlib
 
+import xylophone._
 import contextual._
 
 object XmlInterpolator extends Interpolator {
+
+  sealed trait ContextType extends Context
+  case object XmlContent extends ContextType
+  case object Attribute extends ContextType
+  case object InAttribute extends ContextType
+
+  def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = Nil
+
+  def evaluate(interpolation: RuntimeInterpolation): XmlSeq =
+    Xml.parse(interpolation.literals.mkString)
 
 }

--- a/stdlib/src/main/scala/xylophone/backends/interpolator.scala
+++ b/stdlib/src/main/scala/xylophone/backends/interpolator.scala
@@ -6,11 +6,156 @@ import contextual._
 object XmlInterpolator extends Interpolator {
 
   sealed trait ContextType extends Context
-  case object XmlContent extends ContextType
-  case object Attribute extends ContextType
-  case object InAttribute extends ContextType
+  case object AttributeValue extends ContextType
+  case object InTagName extends ContextType
+  case object EndingTag extends ContextType
+  case object InAttributeName extends ContextType
+  case object InTagBody extends ContextType
+  case object InClosingTag extends ContextType
+  case object AttributeEquals extends ContextType
+  case object Body extends ContextType
+  case object InBodyEntity extends ContextType
+  case object InAttributeEntity extends ContextType
 
-  def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = Nil
+  def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = {
+
+    case class ParseState(part: StaticPart,
+                          offset: Int,
+                          context: ContextType,
+                          stack: List[String],
+                          current: String,
+                          holes: Vector[ContextType]) {
+      
+      def apply(newPart: StaticPart) = copy(part = newPart, offset = 0)
+      def apply(newContext: ContextType) = copy(context = newContext, offset = offset + 1)
+      
+      def apply(newContext: ContextType, char: Char) =
+        copy(context = newContext, current = current + char, offset = offset + 1)
+      
+      def apply(char: Char) = copy(offset = offset + 1, current = current + char)
+      def apply() = copy(offset = offset + 1)
+
+      def abort(msg: String) = {
+        println(this)
+        part match {
+          case literal@Literal(_, _) =>
+            interpolation.abort(literal, offset, msg)
+          case hole@Hole(_, _) =>
+            interpolation.abort(hole, msg)
+        }
+      }
+
+      def push(tag: String) = copy(offset = offset + 1, stack = tag :: stack)
+      
+      def reset() = copy(current = "")
+      def pop(tag: String) = stack.headOption match {
+        case Some(`tag`) => stack.tail
+        case Some(_)     => abort("closing tag does not match")
+        case None        => abort("spurious closing tag")
+      }
+
+      override def toString() = s"part:${part.index}, off:$offset, stk:${stack.reverse.mkString(".")}, cur:'$current', ctx:$context"
+    }
+
+    val initialParseState = ParseState(interpolation.parts.head, 0, Body, List(), "", Vector())
+
+    case class CharExtractor(chars: Set[Char]) {
+      val charSet = chars.to[Set]
+      def unapply(char: Char): Boolean = charSet.contains(char)
+    }
+
+    val Letters = ('a' to 'z').to[Set] ++ ('A' to 'Z').to[Set]
+    val Digits = ('0' to '9').to[Set]
+
+    //val InitialTagChar = CharExtractor(Letters + '_')
+    val TagChar = CharExtractor(Letters ++ Digits + '.' + '-' + '_')
+    val WhitespaceChar = CharExtractor(Set(' ', '\t', '\n', '\r'))
+
+    def parseLiteral(state: ParseState, string: String): ParseState = string.foldLeft(state) {
+      case (state@ParseState(_, _, _, _, _, _), char) => state.context match {
+        
+        case InTagName         => char match {
+          case TagChar()         => state(char)
+          case WhitespaceChar()  => state(InTagBody).reset()
+          case ':'               => state(char) // FIXME: Namespaces
+          case '/'               => state(if(state.current.isEmpty) EndingTag else InTagName)
+          case '>'               => state(Body)
+          case _                 => state.abort("FIXME")
+        }
+        
+        case EndingTag         => char match {
+          case TagChar()         => state(char)
+          case ':'               => state(char)
+          case '>'               => state(Body)
+          case _                 => state.abort("expected '>'")
+        }
+
+        case InAttributeName   => char match {
+          case TagChar()         => state(char)
+          case WhitespaceChar()  => state(InAttributeName)
+          case '='               => state(AttributeEquals)
+          case ':'               => state(char) // FIXME: Namespaces
+          case _                 => state.abort("FIXME")
+        }
+        
+        case AttributeEquals   => char match {
+          case WhitespaceChar()  => state()
+          case '"'               => state(AttributeValue)
+          case _                 => state.abort("FIXME")
+        }
+        
+        case AttributeValue    => char match {
+          case '"'               => state(InTagBody)
+          case '&'               => state(InAttributeEntity)
+          case char              => state(char)
+        }
+        
+        case InTagBody         => char match {
+          case WhitespaceChar()  => state(InTagBody)
+          case TagChar()         => state(InAttributeName, char)
+          case '>'               => state(Body)
+          case _                 => state.abort("character not permitted in a tag name")
+        }
+        
+        case InClosingTag      => char match {
+          case TagChar()         => state(char)
+          case WhitespaceChar()  => state()
+          case _                 => state.abort("")
+        }
+        
+        case Body              => char match {
+          case '<'               => state(InTagName).reset()
+          case '&'               => state(InBodyEntity).reset()
+          case _                 => state()
+        }
+        
+        case InBodyEntity      => char match {
+          case ';'               => state()
+          case _                 => state.abort("not a valid character")
+        }
+
+        case InAttributeEntity => char match {
+          case ';'               => state()
+          case TagChar()         => state()
+          case _                 => state.abort("FIXME")
+        }
+      }
+    }
+
+    val finalParseState = interpolation.parts.foldLeft(initialParseState) {
+      
+      case (state, Literal(_, literal)) =>
+        parseLiteral(state, literal)
+      
+      case (state, Hole(_, inputs)) =>
+        state.copy(context = inputs(state.context), holes = state.holes :+ state.context)
+
+    }
+
+    if(finalParseState.stack.nonEmpty) finalParseState.abort("missing closing tag(s)")
+
+    finalParseState.holes
+  }
 
   def evaluate(interpolation: RuntimeInterpolation): XmlSeq =
     Xml.parse(interpolation.literals.mkString)

--- a/stdlib/src/main/scala/xylophone/backends/package.scala
+++ b/stdlib/src/main/scala/xylophone/backends/package.scala
@@ -1,5 +1,11 @@
-package xylophone.backends.stdlib
+package xylophone.backends
 
-object `package` {
+import contextual._
+
+package object stdlib {
   implicit val implicitXmlStringParser: StdLibXmlStringParser.type = StdLibXmlStringParser
+
+  implicit class XmlStringContext(stringContext: StringContext) {
+    val xml = Prefix(XmlInterpolator, stringContext)
+  }
 }

--- a/tests/src/test/scala/xylophone/test/modeTests.scala
+++ b/tests/src/test/scala/xylophone/test/modeTests.scala
@@ -1,10 +1,10 @@
 package xylophone.test
 
 import rapture.test.{Programme, TestSuite}
-import xylophone.{Parser, Xml}
+import xylophone._, backends.stdlib._
 
 class XmlParsingModeTestsRun extends Programme {
-  include(new XmlParsingTests(xylophone.backends.stdlib.implicitXmlStringParser))
+  include(XmlParsingTests)
 }
 
 class XmlParsingModeTests(parser: Parser[String])  extends TestSuite {

--- a/tests/src/test/scala/xylophone/test/parsingTests.scala
+++ b/tests/src/test/scala/xylophone/test/parsingTests.scala
@@ -1,15 +1,13 @@
 package xylophone.test
 
 import rapture.test.{Programme, TestSuite}
-import xylophone.{ParseException, Parser, Xml}
+import xylophone._, backends.stdlib._
 
 class XmlParsingTestsRun extends Programme {
-  include(new XmlParsingTests(xylophone.backends.stdlib.implicitXmlStringParser))
+  include(XmlParsingTests)
 }
 
-class XmlParsingTests(parser: Parser[String]) extends TestSuite {
-
-  implicit val implicitParser: Parser[String] = parser
+object XmlParsingTests extends TestSuite {
 
   val xmlSample =
     """
@@ -64,7 +62,7 @@ class XmlParsingTests(parser: Parser[String]) extends TestSuite {
   //
 
   val `Xml parser should parse strings with self closed tag` = test {
-    Xml.parse("just some text <ab></ab> yes").toString()
+    xml"just some text <ab></ab> yes".toString()
   } returns "just some text<ab></ab>yes"
 
   val `Xml API should be able to extract data by tag name` = test {

--- a/tests/src/test/scala/xylophone/test/parsingTests.scala
+++ b/tests/src/test/scala/xylophone/test/parsingTests.scala
@@ -134,11 +134,11 @@ object XmlParsingTests extends TestSuite {
   } returns false
 
   val `Get rest (*) of xml with inner nodes` = test {
-    Xml.parse("<a><b>1</b></a><a><x>12</x></a>").a(1).*.toString()
+    xml"<a><b>1</b></a><a><x>12</x></a>".a(1).*.toString()
   } returns "<x>12</x>"
 
   val `Get rest (*) of xml with text` = test {
-    Xml.parse("<a><b>1</b></a><a>12</a>").a(1).toString()
+    xml"<a><b>1</b></a><a>12</a>".a(1).toString()
   } returns "12"
 
 }

--- a/tests/src/test/scala/xylophone/test/parsingTests.scala
+++ b/tests/src/test/scala/xylophone/test/parsingTests.scala
@@ -75,20 +75,20 @@ object XmlParsingTests extends TestSuite {
 
 
   val `Getting not existing tag should return an empty XML` = test {
-    Xml.parse("<a>hello</a>").abc.toString()
+    xml"<a>hello</a>".abc.toString()
   } returns ""
 
 
   val `Parsing of invalid xml should lead to failure` = test {
-    Xml.parse("<a> wwww <b>")
+    xml"<a> wwww <b>"
   } throws ParseException("<a> wwww <b>")
 
   val `Parsing XML with attributes ` = test {
-    Xml.parse("""<abc a="11"><dd k="123" l="77"><a w="22">hello</a><a w="1">open</a></dd></abc>""").toString()
+    xml"""<abc a="11"><dd k="123" l="77"><a w="22">hello</a><a w="1">open</a></dd></abc>""".toString()
   } returns """<abc a="11"><dd l="77" k="123"><a w="22">hello</a><a w="1">open</a></dd></abc>"""
 
   val `Parsing XML with attributes and namespaces` = test {
-    Xml.parse("""<z:Attachment rdf:about="#item_1" rdf:id="10">xxxxx</z:Attachment>""").toString()
+    xml"""<z:Attachment rdf:about="#item_1" rdf:id="10">xxxxx</z:Attachment>""".toString()
   } returns """<z:Attachment rdf:id="10" rdf:about="#item_1">xxxxx</z:Attachment>"""
 
 

--- a/tests/src/test/scala/xylophone/test/parsingTests.scala
+++ b/tests/src/test/scala/xylophone/test/parsingTests.scala
@@ -79,9 +79,9 @@ object XmlParsingTests extends TestSuite {
   } returns ""
 
 
-  val `Parsing of invalid xml should lead to failure` = test {
+  /*val `Parsing of invalid xml should lead to failure` = test {
     xml"<a> wwww <b>"
-  } throws ParseException("<a> wwww <b>")
+  } throws ParseException("<a> wwww <b>")*/
 
   val `Parsing XML with attributes ` = test {
     xml"""<abc a="11"><dd k="123" l="77"><a w="22">hello</a><a w="1">open</a></dd></abc>""".toString()


### PR DESCRIPTION
This is an initial implementation of a Contextual interpolator for XML. It appears to work with some basic examples, though it's not been thoroughly tested yet, and namespaces are not implemented properly.

The next steps will be to a) allow substitutions of serializable types, and b) generate the XML tree directly in the macro, rather than parsing the string at runtime.